### PR TITLE
Add port_in_redirect directive to NGINX configuration template

### DIFF
--- a/conf/app-nginx.conf.sigil
+++ b/conf/app-nginx.conf.sigil
@@ -19,6 +19,7 @@ http {
       root /app/www;
     {{ end }}
     index index.html;
+    port_in_redirect off;
 
     location / {
       try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Copy the fix from https://github.com/mgmco/heroku-buildpack-nginx/pull/3

I believe this fixes the issue reported at https://github.com/dokku/dokku/issues/1184 and a few others (I was encountering the issue when trying to access a directory without a trailing /).