### PR TITLE
Bump pcre version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,7 @@ set -eo pipefail; [[ $TRACE ]] && set -x
 
 NGINX_VERSION="1.10.1"
 NGINX_TARBALL="nginx-${NGINX_VERSION}.tar.gz"
-PCRE_VERSION="8.39"
+PCRE_VERSION="8.41"
 PCRE_TARBALL="pcre-${PCRE_VERSION}.tar.gz"
 SIGIL_VERSION="0.4.0"
 SIGIL_TARBALL="sigil_${SIGIL_VERSION}_Linux_x86_64.tgz"


### PR DESCRIPTION
At some point (ostensibly July 5th, the release date of `pcre-8.41`) `pcre-8.39` was removed from the repository from which this buildpack pulls its dependency. This pull request bumps the pcre version to the latest version released, `8.41`.

This has been tested on dokku `0.9.4`, Ubuntu `14.04.5`, with success.

edit: closed because I just noticed the other pull request waiting.