### PR TITLE
Update PCRE URL

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -54,7 +54,7 @@ fi
 
 if [[ ! -d "${PCRE_TARBALL%.tar.gz}" ]]; then
   echo "-----> Download and unzip pcre ${PCRE_VERSION} via ftp"
-  curl -sSL "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/${PCRE_TARBALL}" -o "${PCRE_TARBALL}"
+  curl -sSL "ftp://ftp.pcre.org/pub/pcre/${PCRE_TARBALL}" -o "${PCRE_TARBALL}"
   tar xzf "${PCRE_TARBALL}" && rm -f "${PCRE_TARBALL}"
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -54,7 +54,7 @@ fi
 
 if [[ ! -d "${PCRE_TARBALL%.tar.gz}" ]]; then
   echo "-----> Download and unzip pcre ${PCRE_VERSION} via ftp"
-  curl -sSL "ftp://ftp.pcre.org/pub/pcre/${PCRE_TARBALL}" -o "${PCRE_TARBALL}"
+  curl -sSL "https://ftp.pcre.org/pub/pcre/${PCRE_TARBALL}" -o "${PCRE_TARBALL}"
   tar xzf "${PCRE_TARBALL}" && rm -f "${PCRE_TARBALL}"
 fi
 


### PR DESCRIPTION
I'm not sure if I was just unlucky, but I could not connect to the ftp.csx.cam.ac.uk URL, while the pcre.org server was working fine:

```
-----> Cleaning up...
-----> Building 0www from herokuish...
-----> Adding BUILD_ENV to build environment...
-----> Warning: Multiple default buildpacks reported the ability to handle this app. The first buildpack in the list below will be used.
       Detected buildpacks: multi ruby static
-----> Multipack app detected
=====> Downloading Buildpack: https://github.com/dokku/buildpack-nginx.git
=====> Detected Framework: .static
-----> Download and unzip pcre 8.43 via ftp
remote: curl: (7) Failed to connect to ftp.csx.cam.ac.uk port 21: Connection refused
```

Of course, feel free to close if this is just a hiccup in the internet :)