### PR TITLE
Add real ip and proxy module

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -101,7 +101,6 @@ if [[ ! -f "${CACHE_DIR}/bin/nginx" ]]; then
     --without-http_map_module \
     --without-http_split_clients_module \
     --without-http_referer_module \
-    --without-http_proxy_module \
     --without-http_fastcgi_module \
     --without-http_uwsgi_module \
     --without-http_scgi_module \
@@ -113,7 +112,8 @@ if [[ ! -f "${CACHE_DIR}/bin/nginx" ]]; then
     --without-http_upstream_keepalive_module \
     --without-mail_pop3_module \
     --without-mail_imap_module \
-    --without-mail_smtp_module
+    --without-mail_smtp_module \
+    --with-http_realip_module
 
   sed -i "/CFLAGS/s/ \-O //g" objs/Makefile
 


### PR DESCRIPTION
Hi. Could you enable those 2 modules? They are needed to enable passing real IP for apps behind Cloudflare proxy as described here: https://www.wpintense.com/2017/03/24/configuring-nginx-pass-real-ip-addresses-cloudflare-compatible-fail2ban-wordpress/ .

I'm using it with success with my fork now.