### PR TITLE
Respond with a 404 when the file doesn't exist

### DIFF
--- a/conf/app-nginx.conf.sigil
+++ b/conf/app-nginx.conf.sigil
@@ -23,7 +23,7 @@ http {
     port_in_redirect off;
 
     location / {
-      try_files $uri $uri/ /index.html;
+      try_files $uri $uri/ =404;
     }
   }
 }


### PR DESCRIPTION
Hello! As I was making sure that my static site was working with my new Dokku install, I noticed that pages like `/wp-admin.php` was successfully (HTTP 200) responding with the contents of my index page.

I tested this change on my site by adding a custom `app-nginx.conf.sigil` to my project, and it seems to be working successfully. I still see my index page when visiting `/`, but I see the Nginx's default 404 error page when visiting locations that do not exist.

I don't think this is too serious, but this could affect how search engines crawl your site. For example, `/wp-admin.php` might show up as a search result with the contents of your home page.