### PR TITLE
feat: allow overriding default 404 response with custom file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ You can override the nginx root via setting the `NGINX_ROOT` environment variabl
 dokku config:set static-app NGINX_ROOT=_site
 ````
 
+### Default to index for history routing
+
+By default, this buildpack will 404 if a requested file is not found. For static sites that use the browser's history router to show the correct context, setting the `NGINX_DEFAULT_REQUEST` to a specific file will override this.
+
+```shell
+# where the app is named `static-app`
+# and the desired default response is index.html
+dokku config:set static-app NGINX_ROOT=index.html
+```
+
 ### Custom nginx config file
 
 You may completely override the built-in nginx config by placing an `app-nginx.conf.sigil` file in the root, modeled after our own [`conf/app-nginx.conf.sigil`](https://github.com/dokku/buildpack-nginx/blob/master/conf/app-nginx.conf.sigil). This will be used inside of the container, and not by the host Dokku instance. See the [sigil project](https://github.com/gliderlabs/sigil) for more information concerning the sigil format.

--- a/bin/compile
+++ b/bin/compile
@@ -144,7 +144,7 @@ if [ -f "$BUILD_DIR/app-nginx.conf.sigil" ] ; then
 
 # Allow deprecated nginx.conf.erb
 elif [ -f "$BUILD_DIR/nginx.conf.erb" ] ; then
-  echo "-----> DEPRECATED: using user provided nginx.conf.erb"
+  echo "-----> DEPRECATED: Using user provided nginx.conf.erb"
   cp "$BUILD_DIR/nginx.conf.erb" "$BUILD_DIR/nginx/nginx.conf.erb"
 
 # ...else, force default file
@@ -168,7 +168,7 @@ cat <<EOF >"$BUILD_DIR/start_nginx"
 #!/usr/bin/env bash
 rm -f /app/nginx/nginx.conf
 if [[ -f /app/nginx/app-nginx.conf.sigil ]]; then
-  /app/sigil/sigil -f /app/nginx/app-nginx.conf.sigil NGINX_ROOT="\$NGINX_ROOT" PORT="\$PORT" | cat -s > /app/nginx/nginx.conf
+  /app/sigil/sigil -f /app/nginx/app-nginx.conf.sigil NGINX_ROOT="\$NGINX_ROOT" NGINX_DEFAULT_REQUEST="\$NGINX_DEFAULT_REQUEST" PORT="\$PORT" | cat -s > /app/nginx/nginx.conf
 else
   erb /app/nginx/nginx.conf.erb > /app/nginx/nginx.conf
 fi

--- a/conf/app-nginx.conf.sigil
+++ b/conf/app-nginx.conf.sigil
@@ -23,7 +23,11 @@ http {
     port_in_redirect off;
 
     location / {
-      try_files $uri $uri/ =404;
+      {{ if ne $.NGINX_DEFAULT_REQUEST "" }}
+        try_files $uri $uri/ /{{ $.NGINX_DEFAULT_REQUEST }};
+      {{ else }}
+        try_files $uri $uri/ =404;
+      {{ end }}
     }
   }
 }


### PR DESCRIPTION
This allows folks the ability to restore the previous routing functionality used by static sites backed by VueJS (as an example).

Note that all requests routed this way will respond with a '200 OK' on the server, potentially causing SEO issues.

Closes #53