### PR TITLE
Split out workflows so that review app cleanup is properly run

### DIFF
--- a/.github/workflows/review-app-cleanup.yml
+++ b/.github/workflows/review-app-cleanup.yml
@@ -1,0 +1,23 @@
+---
+name: 'deploy'
+
+# yamllint disable-line rule:truthy
+on:
+  # onl run this workflow on pull request events
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  destroy_review_app:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Destroy the review app
+        uses: dokku/github-action@master
+        with:
+          # destroy a review app
+          command: review-apps:destroy
+          git_remote_url: 'ssh://dokku@dokku.me:22/nginx-buildpack'
+          # specify a name for the review app
+          review_app_name: nginx-buildpack-${{ github.event.pull_request.number }}
+          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/review-app-cleanup.yml
+++ b/.github/workflows/review-app-cleanup.yml
@@ -1,5 +1,5 @@
 ---
-name: 'deploy'
+name: 'review-app-cleanup'
 
 # yamllint disable-line rule:truthy
 on:

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -26,18 +26,3 @@ jobs:
           # specify a name for the review app
           review_app_name: nginx-buildpack-${{ github.event.pull_request.number }}
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-  destroy_review_app:
-    runs-on: ubuntu-latest
-    # only run when a pull request is closed
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    steps:
-      - name: Destroy the review app
-        uses: dokku/github-action@master
-        with:
-          # destroy a review app
-          command: review-apps:destroy
-          git_remote_url: 'ssh://dokku@dokku.me:22/nginx-buildpack'
-          # specify a name for the review app
-          review_app_name: nginx-buildpack-${{ github.event.pull_request.number }}
-          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -1,5 +1,5 @@
 ---
-name: 'deploy'
+name: 'review-app'
 
 # yamllint disable-line rule:truthy
 on:


### PR DESCRIPTION
The old setup - copy-pasted from the internet somewhere - was incorrect based on how github actions works. *sigh*