### PR TITLE
Add wasm mime type

### DIFF
--- a/conf/mime.types
+++ b/conf/mime.types
@@ -39,6 +39,7 @@ types {
     application/vnd.wap.wmlc              wmlc;
     application/vnd.google-earth.kml+xml  kml;
     application/vnd.google-earth.kmz      kmz;
+    application/wasm                      wasm;
     application/x-7z-compressed           7z;
     application/x-cocoa                   cco;
     application/x-java-archive-diff       jardiff;


### PR DESCRIPTION
This is needed for support of WASM standard' https://www.w3.org/TR/wasm-web-api-1/#streaming-modules instantiateStreaming and compileStreaming, 

and causes errors like

```
WASM: wasm streaming compile failed: TypeError: Failed to execute 'compile' on 'WebAssembly': Incorrect response MIME type. Expected 'application/wasm'.
```

since plain text is returned instead.

It also doesn't seem to be easily fixable even with `nginx.conf.sigil` substitution