### PR TITLE
Nginx version 1.26.2 and download nginx via https

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -3,7 +3,7 @@
 set -eo pipefail
 [[ $TRACE ]] && set -x
 
-NGINX_VERSION="1.25.2"
+NGINX_VERSION="1.26.2"
 NGINX_TARBALL="nginx-${NGINX_VERSION}.tar.gz"
 PCRE_VERSION="10.42"
 PCRE_TARBALL="pcre2-${PCRE_VERSION}.tar.gz"
@@ -51,7 +51,7 @@ cd "$CACHE_DIR"
 
 if [[ ! -d "${NGINX_TARBALL%.tar.gz}" ]]; then
   echo "-----> Download and unzip nginx ${NGINX_VERSION} via http"
-  curl -sSL "http://nginx.org/download/${NGINX_TARBALL}" -o "${NGINX_TARBALL}"
+  curl -sSL "https://nginx.org/download/${NGINX_TARBALL}" -o "${NGINX_TARBALL}"
   tar xzf "${NGINX_TARBALL}" && rm -f "${NGINX_TARBALL}"
 fi
 


### PR DESCRIPTION
Running this buildpack gave the following error:
```
remote: -----> Download and unzip nginx 1.25.2 via http        
remote: curl: (28) Failed to connect to nginx.org port 80 after 215513 ms: Connection timed out  
```

Looking on the nginx download website (https://nginx.org/en/download.html), version 1.25.2 seems not to be available anymore. So I updated to the latest stable version 1.26.2.

Additionally I would like to propose switching the download from http to https, as it is already the case for the other downloads.
