### PR TITLE
feat: support nginx custom parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can override the nginx root via setting the `NGINX_ROOT` environment variabl
 # where the app is named `static-app`
 # and the root dir is _site
 dokku config:set static-app NGINX_ROOT=_site
-````
+```
 
 ### Default to index for history routing
 
@@ -40,6 +40,23 @@ By default, this buildpack will 404 if a requested file is not found. For static
 # where the app is named `static-app`
 # and the desired default response is index.html
 dokku config:set static-app NGINX_DEFAULT_REQUEST=index.html
+```
+
+### Custom nginx directives
+
+You can configure following nginx directives via environment variables.
+
+- `NGINX_WORKERS` : `worker_processes` directive
+- `NGINX_WORKER_CONNECTIONS` : `worker_connections` directive
+- `NGINX_CLIENT_BODY_TIMEOUT` : `client_body_timeout` directive
+- `NGINX_CLIENT_MAX_BODY_SIZE` : `client_max_body_size` directive (in MB)
+
+```shell
+# where the app is named `static-app`
+dokku config:set static-app NGINX_WORKERS=4 \
+                            NGINX_WORKER_CONNECTIONS=1024 \
+                            NGINX_CLIENT_BODY_TIMEOUT=5 \
+                            NGINX_CLIENT_MAX_BODY_SIZE=1
 ```
 
 ### Custom nginx config file

--- a/bin/compile
+++ b/bin/compile
@@ -174,7 +174,7 @@ cat <<EOF >"$BUILD_DIR/start_nginx"
 #!/usr/bin/env bash
 rm -f /app/nginx/nginx.conf
 if [[ -f /app/nginx/app-nginx.conf.sigil ]]; then
-  /app/sigil/sigil -f /app/nginx/app-nginx.conf.sigil NGINX_ROOT="\$NGINX_ROOT" NGINX_DEFAULT_REQUEST="\$NGINX_DEFAULT_REQUEST" PORT="\$PORT" | cat -s > /app/nginx/nginx.conf
+  /app/sigil/sigil -f /app/nginx/app-nginx.conf.sigil NGINX_ROOT="\$NGINX_ROOT" NGINX_DEFAULT_REQUEST="\$NGINX_DEFAULT_REQUEST" NGINX_WORKERS="\$NGINX_WORKERS" NGINX_WORKER_CONNECTIONS="\$NGINX_WORKER_CONNECTIONS" NGINX_CLIENT_BODY_TIMEOUT="\$NGINX_CLIENT_BODY_TIMEOUT" NGINX_CLIENT_MAX_BODY_SIZE="\$NGINX_CLIENT_MAX_BODY_SIZE" PORT="\$PORT" | cat -s > /app/nginx/nginx.conf
 else
   erb /app/nginx/nginx.conf.erb > /app/nginx/nginx.conf
 fi

--- a/conf/app-nginx.conf.sigil
+++ b/conf/app-nginx.conf.sigil
@@ -1,19 +1,38 @@
-worker_processes 1;
+{{ if ne $.NGINX_WORKERS "" }}
+  worker_processes {{ $.NGINX_WORKERS }};
+{{ else }}
+  worker_processes 1;
+{{ end }}
 error_log stderr;
 pid nginx.pid;
 daemon off;
 
 events {
-  worker_connections 768;
+  {{ if ne $.NGINX_WORKER_CONNECTIONS "" }}
+    worker_connections {{ $.NGINX_WORKER_CONNECTIONS }};
+  {{ else }}
+    worker_connections 768;
+  {{ end }}
 }
 
 http {
+  {{ if ne $.NGINX_CLIENT_BODY_TIMEOUT "" }}
+    client_body_timeout {{ $.NGINX_CLIENT_BODY_TIMEOUT }};
+  {{ else }}
+    client_body_timeout 5;
+  {{ end }}
   types_hash_max_size 2048;
   include mime.types;
   charset UTF-8;
+
   server {
     listen {{ $.PORT }};
     server_name  _;
+    {{ if ne $.NGINX_CLIENT_MAX_BODY_SIZE "" }}
+      client_max_body_size {{ $.NGINX_CLIENT_MAX_BODY_SIZE }}M;
+    {{ else }}
+      client_max_body_size 1M;
+    {{ end }}
     {{ if ne $.NGINX_ROOT "" }}
       root /app/www/{{ $.NGINX_ROOT }};
     {{ else }}


### PR DESCRIPTION
I am migrating my applications from Heroku to Dokku.

Previously, I used [heroku-buildpack-nginx](https://github.com/heroku/heroku-buildpack-nginx) with the following environment variables to configure Nginx.
(Please also see [heroku-buildpack-nginx/blob/main/config/nginx-static.conf.erb](https://github.com/heroku/heroku-buildpack-nginx/blob/main/config/nginx-static.conf.erb) .)

- `NGINX_WORKERS` : `worker_processes` directive
- `NGINX_WORKER_CONNECTIONS` : `worker_connections` directive

I make configurable these Nginx directives via environment variables.
Could you review the pull request?