### PR TITLE
feat: precompile nginx binary on release and download during builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,61 +13,23 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Extract version variables
-        id: versions
-        run: |
-          NGINX_VERSION=$(grep '^NGINX_VERSION=' bin/compile | cut -d'"' -f2)
-          PCRE_VERSION=$(grep '^PCRE_VERSION=' bin/compile | cut -d'"' -f2)
-          ZLIB_VERSION=$(grep '^ZLIB_VERSION=' bin/compile | cut -d'"' -f2)
-          echo "NGINX_VERSION=$NGINX_VERSION" >> "$GITHUB_OUTPUT"
-          echo "PCRE_VERSION=$PCRE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "ZLIB_VERSION=$ZLIB_VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Download source tarballs
         run: |
+          source "$GITHUB_WORKSPACE/conf/nginx-configure-flags"
           cd /tmp
-          curl -sSL "https://nginx.org/download/nginx-${{ steps.versions.outputs.NGINX_VERSION }}.tar.gz" | tar xz
-          curl -sSL "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${{ steps.versions.outputs.PCRE_VERSION }}/pcre2-${{ steps.versions.outputs.PCRE_VERSION }}.tar.gz" | tar xz
-          curl -sSL "https://github.com/madler/zlib/archive/v${{ steps.versions.outputs.ZLIB_VERSION }}.tar.gz" | tar xz
+          curl -sSL "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" | tar xz
+          curl -sSL "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${PCRE_VERSION}/pcre2-${PCRE_VERSION}.tar.gz" | tar xz
+          curl -sSL "https://github.com/madler/zlib/archive/v${ZLIB_VERSION}.tar.gz" | tar xz
 
       - name: Compile nginx
         run: |
-          cd /tmp/nginx-${{ steps.versions.outputs.NGINX_VERSION }}
+          source "$GITHUB_WORKSPACE/conf/nginx-configure-flags"
+          cd /tmp/nginx-${NGINX_VERSION}
           ./configure \
-            --with-cpu-opt=generic \
             --prefix=/tmp/nginx-build \
-            --with-pcre=../pcre2-${{ steps.versions.outputs.PCRE_VERSION }} \
-            --sbin-path=. \
-            --pid-path=./nginx.pid \
-            --conf-path=./nginx.conf \
-            --with-ld-opt="-static" \
-            --with-http_stub_status_module \
-            --with-http_gzip_static_module \
-            --with-file-aio \
-            --with-zlib=../zlib-${{ steps.versions.outputs.ZLIB_VERSION }} \
-            --with-pcre \
-            --with-cc-opt="-O2 -static -static-libgcc" \
-            --without-http_ssi_module \
-            --without-http_userid_module \
-            --without-http_access_module \
-            --without-http_autoindex_module \
-            --without-http_geo_module \
-            --without-http_map_module \
-            --without-http_split_clients_module \
-            --without-http_referer_module \
-            --without-http_fastcgi_module \
-            --without-http_uwsgi_module \
-            --without-http_scgi_module \
-            --without-http_memcached_module \
-            --without-http_empty_gif_module \
-            --without-http_browser_module \
-            --without-http_upstream_ip_hash_module \
-            --without-http_upstream_least_conn_module \
-            --without-http_upstream_keepalive_module \
-            --without-mail_pop3_module \
-            --without-mail_imap_module \
-            --without-mail_smtp_module \
-            --with-http_realip_module
+            --with-pcre=../pcre2-${PCRE_VERSION} \
+            --with-zlib=../zlib-${ZLIB_VERSION} \
+            "${NGINX_CONFIGURE_FLAGS[@]}"
           sed -i "/CFLAGS/s/ \-O //g" objs/Makefile
           make -j"$(nproc)"
           cp objs/nginx /tmp/nginx-linux-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+---
+name: "release"
+
+# yamllint disable-line rule:truthy
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Extract version variables
+        id: versions
+        run: |
+          NGINX_VERSION=$(grep '^NGINX_VERSION=' bin/compile | cut -d'"' -f2)
+          PCRE_VERSION=$(grep '^PCRE_VERSION=' bin/compile | cut -d'"' -f2)
+          ZLIB_VERSION=$(grep '^ZLIB_VERSION=' bin/compile | cut -d'"' -f2)
+          echo "NGINX_VERSION=$NGINX_VERSION" >> "$GITHUB_OUTPUT"
+          echo "PCRE_VERSION=$PCRE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "ZLIB_VERSION=$ZLIB_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download source tarballs
+        run: |
+          cd /tmp
+          curl -sSL "https://nginx.org/download/nginx-${{ steps.versions.outputs.NGINX_VERSION }}.tar.gz" | tar xz
+          curl -sSL "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${{ steps.versions.outputs.PCRE_VERSION }}/pcre2-${{ steps.versions.outputs.PCRE_VERSION }}.tar.gz" | tar xz
+          curl -sSL "https://github.com/madler/zlib/archive/v${{ steps.versions.outputs.ZLIB_VERSION }}.tar.gz" | tar xz
+
+      - name: Compile nginx
+        run: |
+          cd /tmp/nginx-${{ steps.versions.outputs.NGINX_VERSION }}
+          ./configure \
+            --with-cpu-opt=generic \
+            --prefix=/tmp/nginx-build \
+            --with-pcre=../pcre2-${{ steps.versions.outputs.PCRE_VERSION }} \
+            --sbin-path=. \
+            --pid-path=./nginx.pid \
+            --conf-path=./nginx.conf \
+            --with-ld-opt="-static" \
+            --with-http_stub_status_module \
+            --with-http_gzip_static_module \
+            --with-file-aio \
+            --with-zlib=../zlib-${{ steps.versions.outputs.ZLIB_VERSION }} \
+            --with-pcre \
+            --with-cc-opt="-O2 -static -static-libgcc" \
+            --without-http_ssi_module \
+            --without-http_userid_module \
+            --without-http_access_module \
+            --without-http_autoindex_module \
+            --without-http_geo_module \
+            --without-http_map_module \
+            --without-http_split_clients_module \
+            --without-http_referer_module \
+            --without-http_fastcgi_module \
+            --without-http_uwsgi_module \
+            --without-http_scgi_module \
+            --without-http_memcached_module \
+            --without-http_empty_gif_module \
+            --without-http_browser_module \
+            --without-http_upstream_ip_hash_module \
+            --without-http_upstream_least_conn_module \
+            --without-http_upstream_keepalive_module \
+            --without-mail_pop3_module \
+            --without-mail_imap_module \
+            --without-mail_smtp_module \
+            --with-http_realip_module
+          sed -i "/CFLAGS/s/ \-O //g" objs/Makefile
+          make -j"$(nproc)"
+          cp objs/nginx /tmp/nginx-linux-amd64
+          chmod +x /tmp/nginx-linux-amd64
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            /tmp/nginx-linux-amd64

--- a/bin/ci-pre-deploy
+++ b/bin/ci-pre-deploy
@@ -20,7 +20,7 @@ if [ "$IS_REVIEW_APP" = "true" ]; then
   git commit -qm "feat: specify custom mime.types"
 
   echo "-----> Setting the buildpack to the current ref $GITHUB_HEAD_REF"
-  echo "https://github.com/${GITHUB_REPOSITORY}.git#$GITHUB_HEAD_REF" > .buildpacks
+  echo "https://github.com/${GITHUB_REPOSITORY}.git#$GITHUB_HEAD_REF" >.buildpacks
   git add .buildpacks
   git commit -qm "feat: specify $GITHUB_SHA as buildpack"
 

--- a/bin/compile
+++ b/bin/compile
@@ -14,6 +14,7 @@ SIGIL_VERSION="0.11.5"
 # https://github.com/madler/zlib/releases
 ZLIB_VERSION="1.3.2"
 ZLIB_TARBALL="zlib-${ZLIB_VERSION}.tar.gz"
+BUILDPACK_REPO="dokku/heroku-buildpack-nginx"
 
 suppress() {
   /bin/rm --force /tmp/surpress.out 2>/dev/null
@@ -52,24 +53,6 @@ fi
 
 cd "$CACHE_DIR"
 
-if [[ ! -d "${NGINX_TARBALL%.tar.gz}" ]]; then
-  echo "-----> Download and unzip nginx ${NGINX_VERSION} via http"
-  curl -sSL "https://nginx.org/download/${NGINX_TARBALL}" -o "${NGINX_TARBALL}"
-  tar xzf "${NGINX_TARBALL}" && rm -f "${NGINX_TARBALL}"
-fi
-
-if [[ ! -d "${PCRE_TARBALL%.tar.gz}" ]]; then
-  echo "-----> Download and unzip pcre ${PCRE_VERSION} via http"
-  curl -sSL "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${PCRE_VERSION}/${PCRE_TARBALL}" -o "${PCRE_TARBALL}"
-  tar xzf "${PCRE_TARBALL}" && rm -f "${PCRE_TARBALL}"
-fi
-
-if [[ ! -d "${ZLIB_TARBALL%.tar.gz}" ]]; then
-  echo "-----> Download and unzip zlib ${ZLIB_VERSION} via http"
-  curl -sSL "https://github.com/madler/zlib/archive/v${ZLIB_VERSION}.tar.gz" -o "${ZLIB_TARBALL}"
-  tar xzf "${ZLIB_TARBALL}" && rm -rf "${ZLIB_TARBALL}"
-fi
-
 mkdir -p "$BUILD_DIR/sigil"
 if [[ ! -f "$BUILD_DIR/sigil/sigil-${SIGIL_VERSION}" ]]; then
   echo "-----> Download and unzip sigil ${SIGIL_VERSION} via http"
@@ -83,8 +66,40 @@ if [[ ! -f "$BUILD_DIR/sigil/sigil" ]]; then
   exit 1
 fi
 
-cd "nginx-${NGINX_VERSION}"
-if [[ ! -f "${CACHE_DIR}/bin/nginx" ]]; then
+if [[ -f "${CACHE_DIR}/bin/nginx" ]]; then
+  echo "-----> Reusing nginx binary from cache"
+  mkdir -p "$BUILD_DIR/nginx"
+  # shellcheck disable=SC2086
+  cp -r $CACHE_DIR/bin/* "$BUILD_DIR/nginx/"
+
+elif curl -fsSL "https://github.com/${BUILDPACK_REPO}/releases/latest/download/nginx-linux-amd64" -o /tmp/nginx-linux-amd64 2>/dev/null; then
+  echo "-----> Using precompiled nginx binary"
+  mkdir -p "$BUILD_DIR/nginx" "${CACHE_DIR}/bin"
+  chmod +x /tmp/nginx-linux-amd64
+  cp /tmp/nginx-linux-amd64 "$BUILD_DIR/nginx/nginx"
+  cp /tmp/nginx-linux-amd64 "${CACHE_DIR}/bin/nginx"
+  rm -f /tmp/nginx-linux-amd64
+
+else
+  if [[ ! -d "${NGINX_TARBALL%.tar.gz}" ]]; then
+    echo "-----> Download and unzip nginx ${NGINX_VERSION} via http"
+    curl -sSL "https://nginx.org/download/${NGINX_TARBALL}" -o "${NGINX_TARBALL}"
+    tar xzf "${NGINX_TARBALL}" && rm -f "${NGINX_TARBALL}"
+  fi
+
+  if [[ ! -d "${PCRE_TARBALL%.tar.gz}" ]]; then
+    echo "-----> Download and unzip pcre ${PCRE_VERSION} via http"
+    curl -sSL "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${PCRE_VERSION}/${PCRE_TARBALL}" -o "${PCRE_TARBALL}"
+    tar xzf "${PCRE_TARBALL}" && rm -f "${PCRE_TARBALL}"
+  fi
+
+  if [[ ! -d "${ZLIB_TARBALL%.tar.gz}" ]]; then
+    echo "-----> Download and unzip zlib ${ZLIB_VERSION} via http"
+    curl -sSL "https://github.com/madler/zlib/archive/v${ZLIB_VERSION}.tar.gz" -o "${ZLIB_TARBALL}"
+    tar xzf "${ZLIB_TARBALL}" && rm -rf "${ZLIB_TARBALL}"
+  fi
+
+  cd "nginx-${NGINX_VERSION}"
   echo "-----> Compiling static nginx binary"
   mkdir "$BUILD_DIR/nginx"
   suppress ./configure \
@@ -130,12 +145,6 @@ if [[ ! -f "${CACHE_DIR}/bin/nginx" ]]; then
   rm -rf "${CACHE_DIR:?}/bin" && mkdir -p "$CACHE_DIR/bin/"
   # shellcheck disable=SC2086
   cp -r $BUILD_DIR/nginx/* "$CACHE_DIR/bin/"
-
-else
-  echo "-----> Reusing nginx binary from cache"
-  mkdir -p "$BUILD_DIR/nginx"
-  # shellcheck disable=SC2086
-  cp -r $CACHE_DIR/bin/* "$BUILD_DIR/nginx/"
 fi
 
 # Update the PATH

--- a/bin/compile
+++ b/bin/compile
@@ -3,16 +3,10 @@
 set -eo pipefail
 [[ $TRACE ]] && set -x
 
-# https://nginx.org/en/download.html
-NGINX_VERSION="1.29.8"
+# shellcheck source=conf/nginx-configure-flags
+source "$(cd "$(dirname "$0")" && cd .. && pwd)/conf/nginx-configure-flags"
 NGINX_TARBALL="nginx-${NGINX_VERSION}.tar.gz"
-# https://github.com/PCRE2Project/pcre2/releases
-PCRE_VERSION="10.47"
 PCRE_TARBALL="pcre2-${PCRE_VERSION}.tar.gz"
-# https://github.com/gliderlabs/sigil/releases
-SIGIL_VERSION="0.11.5"
-# https://github.com/madler/zlib/releases
-ZLIB_VERSION="1.3.2"
 ZLIB_TARBALL="zlib-${ZLIB_VERSION}.tar.gz"
 BUILDPACK_REPO="dokku/heroku-buildpack-nginx"
 
@@ -103,40 +97,10 @@ else
   echo "-----> Compiling static nginx binary"
   mkdir "$BUILD_DIR/nginx"
   suppress ./configure \
-    --with-cpu-opt=generic \
     --prefix="$BUILD_DIR/nginx" \
     --with-pcre=../pcre2-${PCRE_VERSION} \
-    --sbin-path=. \
-    --pid-path=./nginx.pid \
-    --conf-path=./nginx.conf \
-    --with-ld-opt="-static" \
-    --with-http_stub_status_module \
-    --with-http_gzip_static_module \
-    --with-file-aio \
     --with-zlib=../zlib-${ZLIB_VERSION} \
-    --with-pcre \
-    --with-cc-opt="-O2 -static -static-libgcc" \
-    --without-http_ssi_module \
-    --without-http_userid_module \
-    --without-http_access_module \
-    --without-http_autoindex_module \
-    --without-http_geo_module \
-    --without-http_map_module \
-    --without-http_split_clients_module \
-    --without-http_referer_module \
-    --without-http_fastcgi_module \
-    --without-http_uwsgi_module \
-    --without-http_scgi_module \
-    --without-http_memcached_module \
-    --without-http_empty_gif_module \
-    --without-http_browser_module \
-    --without-http_upstream_ip_hash_module \
-    --without-http_upstream_least_conn_module \
-    --without-http_upstream_keepalive_module \
-    --without-mail_pop3_module \
-    --without-mail_imap_module \
-    --without-mail_smtp_module \
-    --with-http_realip_module
+    "${NGINX_CONFIGURE_FLAGS[@]}"
 
   sed -i "/CFLAGS/s/ \-O //g" objs/Makefile
 

--- a/conf/nginx-configure-flags
+++ b/conf/nginx-configure-flags
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Shared nginx build configuration
+# Sourced by bin/compile and .github/workflows/release.yml
+# shellcheck disable=SC2034
+
+# https://nginx.org/en/download.html
+NGINX_VERSION="1.29.8"
+# https://github.com/PCRE2Project/pcre2/releases
+PCRE_VERSION="10.47"
+# https://github.com/gliderlabs/sigil/releases
+SIGIL_VERSION="0.11.5"
+# https://github.com/madler/zlib/releases
+ZLIB_VERSION="1.3.2"
+
+NGINX_CONFIGURE_FLAGS=(
+  --with-cpu-opt=generic
+  --sbin-path=.
+  --pid-path=./nginx.pid
+  --conf-path=./nginx.conf
+  "--with-ld-opt=-static"
+  --with-http_stub_status_module
+  --with-http_gzip_static_module
+  --with-file-aio
+  --with-pcre
+  "--with-cc-opt=-O2 -static -static-libgcc"
+  --without-http_ssi_module
+  --without-http_userid_module
+  --without-http_access_module
+  --without-http_autoindex_module
+  --without-http_geo_module
+  --without-http_map_module
+  --without-http_split_clients_module
+  --without-http_referer_module
+  --without-http_fastcgi_module
+  --without-http_uwsgi_module
+  --without-http_scgi_module
+  --without-http_memcached_module
+  --without-http_empty_gif_module
+  --without-http_browser_module
+  --without-http_upstream_ip_hash_module
+  --without-http_upstream_least_conn_module
+  --without-http_upstream_keepalive_module
+  --without-mail_pop3_module
+  --without-mail_imap_module
+  --without-mail_smtp_module
+  --with-http_realip_module
+)


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that compiles a statically-linked nginx binary when a release is created and uploads it as a release asset (`nginx-linux-amd64`)
- Modifies `bin/compile` to attempt downloading the precompiled binary from the latest release before falling back to source compilation, significantly speeding up cold-cache deploys
- Source tarball downloads (nginx, pcre2, zlib) are now skipped entirely when a precompiled binary is available