### PR TITLE
feat: set buildpack ref on main branch deploys

### DIFF
--- a/bin/ci-pre-deploy
+++ b/bin/ci-pre-deploy
@@ -25,4 +25,7 @@ if [ "$IS_REVIEW_APP" = "true" ]; then
   git commit -qm "feat: specify $GITHUB_SHA as buildpack"
 
   git rev-parse HEAD >ci-commit-override
+else
+  echo "-----> Setting the buildpack to the current ref $GITHUB_REF_NAME"
+  ssh "$SSH_REMOTE" -- buildpacks:set "$APP_NAME" "https://github.com/${GITHUB_REPOSITORY}.git#${GITHUB_REF_NAME}"
 fi


### PR DESCRIPTION
## Summary

- Adds an `else` branch to `bin/ci-pre-deploy` so main/master deploys set the buildpack ref via `dokku buildpacks:set`
- Uses `GITHUB_REF_NAME` to resolve to `master` or `main` depending on which branch triggered the deploy
- Review app behavior is unchanged