### PR TITLE
fix: create nginx logs directory for precompiled binary builds

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -123,6 +123,9 @@ else
   echo "$NGINX_VERSION" >"${CACHE_DIR}/bin/.nginx-version"
 fi
 
+# Create logs directory for nginx's compiled-in default log paths
+mkdir -p "$BUILD_DIR/nginx/logs"
+
 # Update the PATH
 mkdir -p "$BUILD_DIR/.profile.d"
 cat >"$BUILD_DIR/.profile.d/nginx.sh" <<"EOF"


### PR DESCRIPTION
## Summary

- The precompiled binary and cache code paths introduced in PRs #98/#101 only copy the nginx binary without creating the `logs/` directory that `make install` normally creates when compiling from source
- At startup, nginx tries to open its compiled-in default log paths at `/app/nginx/logs/error.log` and `/app/nginx/logs/access.log` before reading the config file, causing a fatal `[emerg]` error when the directory doesn't exist
- Adds `mkdir -p "$BUILD_DIR/nginx/logs"` after the binary installation block to ensure the directory exists regardless of how the binary was obtained

Fixes the deployment failure in https://github.com/dokku/heroku-buildpack-nginx/actions/runs/24823150053/job/72652433288