### PR TITLE
Cache sigil binary between builds

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -21,7 +21,7 @@ suppress() {
 BUILD_DIR=$1
 CACHE_DIR=$2
 CUR_DIR=$(cd "$(dirname "$0")" && cd .. && pwd)
-SIGIL_CACHE_DIR="${CACHE_DIR}/sigil"
+SIGIL_CACHE_FILE="${CACHE_DIR}/sigil-${SIGIL_VERSION}"
 
 mkdir -p "$BUILD_DIR" "$CACHE_DIR"
 
@@ -48,15 +48,15 @@ fi
 
 cd "$CACHE_DIR"
 
-mkdir -p "$BUILD_DIR/sigil" "$SIGIL_CACHE_DIR"
+mkdir -p "$BUILD_DIR/sigil"
 
-if [[ ! -f "$SIGIL_CACHE_DIR/sigil-${SIGIL_VERSION}" ]]; then
+if [[ ! -f "$SIGIL_CACHE_FILE" ]]; then
   echo "-----> Download and cache sigil ${SIGIL_VERSION} via http"
-  curl -fsSL "https://github.com/gliderlabs/sigil/releases/download/v${SIGIL_VERSION}/sigil-linux-amd64" -o "$SIGIL_CACHE_DIR/sigil-${SIGIL_VERSION}"
+  curl -fsSL "https://github.com/gliderlabs/sigil/releases/download/v${SIGIL_VERSION}/sigil-linux-amd64" -o "$SIGIL_CACHE_FILE"
+  chmod +x "$SIGIL_CACHE_FILE"
 fi
 
-chmod +x "$SIGIL_CACHE_DIR/sigil-${SIGIL_VERSION}"
-cp "$SIGIL_CACHE_DIR/sigil-${SIGIL_VERSION}" "$BUILD_DIR/sigil/sigil-${SIGIL_VERSION}"
+cp "$SIGIL_CACHE_FILE" "$BUILD_DIR/sigil/sigil-${SIGIL_VERSION}"
 cp "$BUILD_DIR/sigil/sigil-${SIGIL_VERSION}" "$BUILD_DIR/sigil/sigil"
 chmod +x "$BUILD_DIR/sigil/sigil"
 

--- a/bin/compile
+++ b/bin/compile
@@ -21,6 +21,7 @@ suppress() {
 BUILD_DIR=$1
 CACHE_DIR=$2
 CUR_DIR=$(cd "$(dirname "$0")" && cd .. && pwd)
+SIGIL_CACHE_DIR="${CACHE_DIR}/sigil"
 
 mkdir -p "$BUILD_DIR" "$CACHE_DIR"
 
@@ -47,14 +48,15 @@ fi
 
 cd "$CACHE_DIR"
 
-mkdir -p "$BUILD_DIR/sigil" "$CACHE_DIR/sigil"
+mkdir -p "$BUILD_DIR/sigil" "$SIGIL_CACHE_DIR"
 
-if [[ ! -f "$CACHE_DIR/sigil/sigil-${SIGIL_VERSION}" ]]; then
+if [[ ! -f "$SIGIL_CACHE_DIR/sigil-${SIGIL_VERSION}" ]]; then
   echo "-----> Download and cache sigil ${SIGIL_VERSION} via http"
-  curl -fsSL "https://github.com/gliderlabs/sigil/releases/download/v${SIGIL_VERSION}/sigil-linux-amd64" -o "$CACHE_DIR/sigil/sigil-${SIGIL_VERSION}"
+  curl -fsSL "https://github.com/gliderlabs/sigil/releases/download/v${SIGIL_VERSION}/sigil-linux-amd64" -o "$SIGIL_CACHE_DIR/sigil-${SIGIL_VERSION}"
 fi
 
-cp "$CACHE_DIR/sigil/sigil-${SIGIL_VERSION}" "$BUILD_DIR/sigil/sigil-${SIGIL_VERSION}"
+chmod +x "$SIGIL_CACHE_DIR/sigil-${SIGIL_VERSION}"
+cp "$SIGIL_CACHE_DIR/sigil-${SIGIL_VERSION}" "$BUILD_DIR/sigil/sigil-${SIGIL_VERSION}"
 cp "$BUILD_DIR/sigil/sigil-${SIGIL_VERSION}" "$BUILD_DIR/sigil/sigil"
 chmod +x "$BUILD_DIR/sigil/sigil"
 

--- a/bin/compile
+++ b/bin/compile
@@ -47,13 +47,16 @@ fi
 
 cd "$CACHE_DIR"
 
-mkdir -p "$BUILD_DIR/sigil"
-if [[ ! -f "$BUILD_DIR/sigil/sigil-${SIGIL_VERSION}" ]]; then
-  echo "-----> Download and unzip sigil ${SIGIL_VERSION} via http"
-  curl -fsSL "https://github.com/gliderlabs/sigil/releases/download/v${SIGIL_VERSION}/sigil-linux-amd64" -o "$BUILD_DIR/sigil/sigil-${SIGIL_VERSION}"
-  cp "$BUILD_DIR/sigil/sigil-${SIGIL_VERSION}" "$BUILD_DIR/sigil/sigil"
-  chmod +x "$BUILD_DIR/sigil/sigil"
+mkdir -p "$BUILD_DIR/sigil" "$CACHE_DIR/sigil"
+
+if [[ ! -f "$CACHE_DIR/sigil/sigil-${SIGIL_VERSION}" ]]; then
+  echo "-----> Download and cache sigil ${SIGIL_VERSION} via http"
+  curl -fsSL "https://github.com/gliderlabs/sigil/releases/download/v${SIGIL_VERSION}/sigil-linux-amd64" -o "$CACHE_DIR/sigil/sigil-${SIGIL_VERSION}"
 fi
+
+cp "$CACHE_DIR/sigil/sigil-${SIGIL_VERSION}" "$BUILD_DIR/sigil/sigil-${SIGIL_VERSION}"
+cp "$BUILD_DIR/sigil/sigil-${SIGIL_VERSION}" "$BUILD_DIR/sigil/sigil"
+chmod +x "$BUILD_DIR/sigil/sigil"
 
 if [[ ! -f "$BUILD_DIR/sigil/sigil" ]]; then
   echo " !     Missing sigil binary"


### PR DESCRIPTION
## Summary

Caches the sigil binary under the buildpack cache directory and copies it into the build directory during each build.

Previously, sigil was downloaded into `$BUILD_DIR/sigil`, which is temporary per build, causing the binary to be downloaded again on every deploy.

## Changes

- Adds `SIGIL_CACHE_DIR="${CACHE_DIR}/sigil"`
- Downloads sigil into the persistent cache directory
- Copies the cached binary into `$BUILD_DIR/sigil`
- Preserves the final `$BUILD_DIR/sigil/sigil` path used by the startup script

## Motivation

On hosts with slow access to GitHub Releases, repeatedly downloading sigil can significantly slow down deploys. In one Dokku deployment, this step took more than 2 minutes.